### PR TITLE
Use morley 0.5.0

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,7 @@ library:
     - fmt
     - morley
     - morley-prelude
+    - morley-ledgers
     - named
     - singletons
     - text
@@ -28,7 +29,6 @@ library:
     - aeson
     - constraints
     - binary
-    - lorentz-contracts
     - optparse-applicative
     - megaparsec
 
@@ -39,9 +39,9 @@ executables:
     dependencies:
       - containers
       - fmt
-      - lorentz-contracts
       - morley
       - morley-prelude
+      - morley-ledgers
       - optparse-applicative
       - singletons
       - text
@@ -57,9 +57,9 @@ executables:
     dependencies:
       - containers
       - fmt
-      - lorentz-contracts
       - morley
       - morley-prelude
+      - morley-ledgers
       - optparse-applicative
       - text
       - named
@@ -82,9 +82,9 @@ executables:
     dependencies:
       - containers
       - fmt
-      - lorentz-contracts
       - morley
       - morley-prelude
+      - morley-ledgers
       - optparse-applicative
       - text
       - named
@@ -104,7 +104,6 @@ tests:
       - hspec
       - hspec-expectations
       - HUnit
-      - lorentz-contracts
       - morley
       - morley-prelude
       - QuickCheck

--- a/package.yaml
+++ b/package.yaml
@@ -2,7 +2,7 @@
 
 <<: *meta
 name:                lorentz-contract-param
-version:             1.2.2.1.0
+version:             2.0.5.0.0
 synopsis:            Set of Michelson contracts implemented in Lorentz eDSL, with CLI interface
 description:
   Various contracts including simple examples.

--- a/param-app/Multisig.hs
+++ b/param-app/Multisig.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS -Wno-missing-export-lists #-}
 
 module Multisig where
 
@@ -28,9 +29,10 @@ import Lorentz.Contracts.Util ()
 import Michelson.Interpret.Pack
 import Michelson.Printer.Util
 import Michelson.Typed
-import Tezos.Crypto (SecretKey)
+-- import Tezos.Crypto (SecretKey)
 import qualified Lorentz.Contracts.GenericMultisig as G
 import qualified Tezos.Crypto as Crypto
+import qualified Tezos.Crypto.Ed25519 as Ed25519
 
 
 -- | A file with everything needed to sign some multisig contract parameters
@@ -181,7 +183,7 @@ readMultisigSignersFile filePath = do
 
 multisigSignFile :: forall key. G.IsKey key
   => Proxy key
-  -> SecretKey
+  -> Ed25519.SecretKey
   -> G.SomePublicKey
   -> FilePath
   -> ExceptT String IO ()
@@ -230,7 +232,7 @@ signatureList MultisigSignersFile {..} =
 
 -- | Sign the parameters in a `MultisigSignersFile`
 signMultisigSignersFile :: forall key.
-     G.Public key -> SecretKey -> MultisigSignersFile key -> MultisigSignersFile key
+     G.Public key -> Ed25519.SecretKey -> MultisigSignersFile key -> MultisigSignersFile key
 signMultisigSignersFile publicKey secretKey multisigSignersFile@MultisigSignersFile {..} =
   case contractParameter of
     Left changeKeyParams' ->

--- a/src/Lorentz/Contracts/GenericMultisig/Wrapper.hs
+++ b/src/Lorentz/Contracts/GenericMultisig/Wrapper.hs
@@ -1,27 +1,29 @@
 {-# OPTIONS -Wno-missing-export-lists #-}
 
-module Lorentz.Contracts.GenericMultisig.Wrapper where
+module Lorentz.Contracts.GenericMultisig.Wrapper {-# WARNING "This module hasn't been updated since Athens" #-} where
 
 import Data.Singletons
 import qualified Data.Text.Lazy as L
-import Data.Constraint hiding (trans)
+-- import Data.Constraint hiding (trans)
 import Text.Megaparsec (eof)
 
 import Lorentz
-import Lorentz.Contracts.ManagedLedger.Types
+-- import Lorentz.Contracts.ManagedLedger.Types
 import Lorentz.Contracts.GenericMultisig
 import Lorentz.Contracts.VarStorage
 import Lorentz.Contracts.Util ()
 import Michelson.Typed.Scope
-import Michelson.Typed.Sing
+-- import Michelson.Typed.Sing
 import Michelson.TypeCheck.TypeCheck
 import Michelson.TypeCheck.Instr
 import Michelson.Typed.T
-import Michelson.Typed.Value
+-- import Michelson.Typed.Value
 import Michelson.Parser hiding (parseValue)
 import Michelson.Macro
-import qualified Lorentz.Contracts.ManagedLedger.Athens as A
-import qualified Michelson.TypeCheck.Types as Ty
+-- import qualified Lorentz.Contracts.ManagedLedger.Athens as A
+-- import qualified Lorentz.Contracts.ManagedLedger as ManagedLedger
+-- import qualified Lorentz.Contracts.ManagedLedger.Types as ManagedLedger
+-- import qualified Michelson.TypeCheck.Types as Ty
 import qualified Michelson.Typed.Instr as Instr
 import Lorentz.Contracts.SomeContractParam
 
@@ -29,7 +31,7 @@ import Control.Applicative
 import Data.Type.Equality
 import Text.Show
 import Data.Typeable
-import Prelude ((<$>), (>>=), Void, absurd, fail, either, flip, runReaderT, fst)
+import Prelude ((<$>), (>>=), Void, fail, either, flip, runReaderT)
 
 -- | Proof that `True` is not `False`
 tfToVoid :: 'True :~: 'False -> Void
@@ -68,113 +70,113 @@ instance ( ContainsBigMap v ~ 'False
   type CBigMapVal ('TPair ('TBigMap k v) t) = v
   type CWithoutBigMap ('TPair ('TBigMap k v) t) = t
 
--- | Proof that `ConstrainedBigMap` is implied by
--- @`ContainsBigMap` t ~ 'True@ and @`BadBigMapPair` t ~ 'False@
-constrainedBigMapRefl ::
-     forall (t :: T).
-     Sing (t :: T)
-  -> (ContainsBigMap t :~: 'True)
-  -> (BadBigMapPair t :~: 'False)
-  -> Dict (ConstrainedBigMap t)
-constrainedBigMapRefl singT containsBigMap noBadBigMapPair =
-  case singT of
-    STc _ -> absurd . tfToVoid $ sym containsBigMap
-    STKey -> absurd . tfToVoid $ sym containsBigMap
-    STSignature -> absurd . tfToVoid $ sym containsBigMap
-    STUnit -> absurd . tfToVoid $ sym containsBigMap
-    STOption t ->
-      case checkBigMapPresence t of
-        BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
-        BigMapAbsent -> absurd . tfToVoid $ sym containsBigMap
-    STList t ->
-      case checkBigMapPresence t of
-        BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
-        BigMapAbsent -> absurd . tfToVoid $ sym containsBigMap
-    STSet _ -> absurd . tfToVoid $ sym containsBigMap
-    STOperation -> absurd . tfToVoid $ sym containsBigMap
-    STContract t ->
-      case checkBigMapPresence t of
-        BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
-        BigMapAbsent -> absurd . tfToVoid $ sym containsBigMap
-    STPair a b ->
-      case a of
-        STBigMap _ v ->
-          case checkBigMapPresence v of
-            BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
-            BigMapAbsent ->
-              case checkBigMapPresence b of
-                BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
-                BigMapAbsent -> Dict
-        STc _ -> absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STKey -> absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STSignature ->
-          absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STUnit -> absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STOption t ->
-          case checkBigMapPresence t of
-            BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
-            BigMapAbsent ->
-              absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STList t ->
-          case checkBigMapPresence t of
-            BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
-            BigMapAbsent ->
-              absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STSet _ ->
-          absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STOperation ->
-          absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STContract t ->
-          case checkBigMapPresence t of
-            BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
-            BigMapAbsent ->
-              absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STPair x y ->
-          case (checkBigMapPresence x, checkBigMapPresence y) of
-            (BigMapPresent, _) -> absurd $ tfToVoid noBadBigMapPair
-            (_, BigMapPresent) -> absurd $ tfToVoid noBadBigMapPair
-            (BigMapAbsent, BigMapAbsent) ->
-              absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STOr x y ->
-          case (checkBigMapPresence x, checkBigMapPresence y) of
-            (BigMapPresent, _) -> absurd $ tfToVoid noBadBigMapPair
-            (_, BigMapPresent) -> absurd $ tfToVoid noBadBigMapPair
-            (BigMapAbsent, BigMapAbsent) ->
-              absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STLambda _ _ ->
-          absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-        STMap _ v ->
-          case checkBigMapPresence v of
-            BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
-            BigMapAbsent ->
-              absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
-    STOr a b ->
-      case (checkBigMapPresence a, checkBigMapPresence b) of
-        (BigMapPresent, _) -> absurd $ tfToVoid noBadBigMapPair
-        (_, BigMapPresent) -> absurd $ tfToVoid noBadBigMapPair
-        (BigMapAbsent, BigMapAbsent) -> absurd . tfToVoid $ sym containsBigMap
-    STLambda _ _ -> absurd . tfToVoid $ sym containsBigMap
-    STMap _ v ->
-      case checkBigMapPresence v of
-        BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
-        BigMapAbsent -> absurd . tfToVoid $ sym containsBigMap
-    STBigMap _ _ -> absurd $ tfToVoid noBadBigMapPair
+-- -- | Proof that `ConstrainedBigMap` is implied by
+-- -- @`ContainsBigMap` t ~ 'True@ and @`BadBigMapPair` t ~ 'False@
+-- constrainedBigMapRefl ::
+--      forall (t :: T).
+--      Sing (t :: T)
+--   -> (ContainsBigMap t :~: 'True)
+--   -- -> (BadBigMapPair t :~: 'False)
+--   -> Dict (ConstrainedBigMap t)
+-- constrainedBigMapRefl singT containsBigMap = -- noBadBigMapPair =
+--   case singT of
+--     STc _ -> absurd . tfToVoid $ sym containsBigMap
+--     STKey -> absurd . tfToVoid $ sym containsBigMap
+--     STSignature -> absurd . tfToVoid $ sym containsBigMap
+--     STUnit -> absurd . tfToVoid $ sym containsBigMap
+--     STOption t ->
+--       case checkBigMapPresence t of
+--         BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
+--         BigMapAbsent -> absurd . tfToVoid $ sym containsBigMap
+--     STList t ->
+--       case checkBigMapPresence t of
+--         BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
+--         BigMapAbsent -> absurd . tfToVoid $ sym containsBigMap
+--     STSet _ -> absurd . tfToVoid $ sym containsBigMap
+--     STOperation -> absurd . tfToVoid $ sym containsBigMap
+--     STContract t ->
+--       case checkBigMapPresence t of
+--         BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
+--         BigMapAbsent -> absurd . tfToVoid $ sym containsBigMap
+--     STPair a b ->
+--       case a of
+--         STBigMap _ v ->
+--           case checkBigMapPresence v of
+--             BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
+--             BigMapAbsent ->
+--               case checkBigMapPresence b of
+--                 BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
+--                 BigMapAbsent -> Dict
+--         STc _ -> absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STKey -> absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STSignature ->
+--           absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STUnit -> absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STOption t ->
+--           case checkBigMapPresence t of
+--             BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
+--             BigMapAbsent ->
+--               absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STList t ->
+--           case checkBigMapPresence t of
+--             BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
+--             BigMapAbsent ->
+--               absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STSet _ ->
+--           absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STOperation ->
+--           absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STContract t ->
+--           case checkBigMapPresence t of
+--             BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
+--             BigMapAbsent ->
+--               absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STPair x y ->
+--           case (checkBigMapPresence x, checkBigMapPresence y) of
+--             (BigMapPresent, _) -> absurd $ tfToVoid noBadBigMapPair
+--             (_, BigMapPresent) -> absurd $ tfToVoid noBadBigMapPair
+--             (BigMapAbsent, BigMapAbsent) ->
+--               absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STOr x y ->
+--           case (checkBigMapPresence x, checkBigMapPresence y) of
+--             (BigMapPresent, _) -> absurd $ tfToVoid noBadBigMapPair
+--             (_, BigMapPresent) -> absurd $ tfToVoid noBadBigMapPair
+--             (BigMapAbsent, BigMapAbsent) ->
+--               absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STLambda _ _ ->
+--           absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--         STMap _ v ->
+--           case checkBigMapPresence v of
+--             BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
+--             BigMapAbsent ->
+--               absurd . tfToVoid $ sym containsBigMap `trans` noBadBigMapPair
+--     STOr a b ->
+--       case (checkBigMapPresence a, checkBigMapPresence b) of
+--         (BigMapPresent, _) -> absurd $ tfToVoid noBadBigMapPair
+--         (_, BigMapPresent) -> absurd $ tfToVoid noBadBigMapPair
+--         (BigMapAbsent, BigMapAbsent) -> absurd . tfToVoid $ sym containsBigMap
+--     STLambda _ _ -> absurd . tfToVoid $ sym containsBigMap
+--     STMap _ v ->
+--       case checkBigMapPresence v of
+--         BigMapPresent -> absurd $ tfToVoid noBadBigMapPair
+--         BigMapAbsent -> absurd . tfToVoid $ sym containsBigMap
+--     STBigMap _ _ -> absurd $ tfToVoid noBadBigMapPair
 
--- | `constrainedBigMapRefl` with the `Refl`'s moved to constraints
-constrainedBigMap ::
-     forall (t :: T). (ContainsBigMap t ~ 'True, BigMapConstraint t)
-  => Sing (t :: T)
-  -> Dict (ConstrainedBigMap t)
-constrainedBigMap singT =
-  constrainedBigMapRefl singT Refl Refl
+-- -- | `constrainedBigMapRefl` with the `Refl`'s moved to constraints
+-- constrainedBigMap ::
+--      forall (t :: T). (ContainsBigMap t ~ 'True) -- , BigMapConstraint t)
+--   => Sing (t :: T)
+--   -> Dict (ConstrainedBigMap t)
+-- constrainedBigMap singT =
+--   constrainedBigMapRefl singT Refl Refl
 
--- | `explicitlyStorePair` when we know that it `ContainsBigMap` and `BigMapConstraint` holds
-explicitlyStorePair' :: forall a b. (SingI (ToT b), ContainsBigMap (ToT b) ~ 'True, BigMapConstraint (ToT b))
-  => Contract a b
-  -> BigMapContract (CValue (CBigMapKey (ToT b))) (Value (CBigMapVal (ToT b))) a (Value (CWithoutBigMap (ToT b)))
-explicitlyStorePair' xs =
-  case constrainedBigMap (sing @(ToT b)) of
-    Dict -> explicitlyStorePair xs
+-- -- | `explicitlyStorePair` when we know that it `ContainsBigMap` and `BigMapConstraint` holds
+-- explicitlyStorePair' :: forall a b. (SingI (ToT b), ContainsBigMap (ToT b) ~ 'True) -- , BigMapConstraint (ToT b))
+--   => Contract a b
+--   -> BigMapContract (CValue (CBigMapKey (ToT b))) (Value (CBigMapVal (ToT b))) a (Value (CWithoutBigMap (ToT b)))
+-- explicitlyStorePair' xs =
+--   case constrainedBigMap (sing @(ToT b)) of
+--     Dict -> explicitlyStorePair xs
 
 -- | If `Contract` has a `BigMap`, use the following to make it explicit
 -- in storage
@@ -186,68 +188,68 @@ explicitlyStorePair baseContract = do
   baseContract
   coerce_
 
--- | If `Contract` does not have a `BigMap`, use the following to
--- add a trivial one.
-ignoreBigMap ::
-     Contract a b
-  -> BigMapContract Bool () a b
-ignoreBigMap baseContract = do
-  unpair
-  swap
-  unpair
-  dip $ do
-    swap
-    pair
-    baseContract
-    unpair
-  swap
-  dip pair
-  pair
+-- -- | If `Contract` does not have a `BigMap`, use the following to
+-- -- add a trivial one.
+-- ignoreBigMap ::
+--      Contract a b
+--   -> BigMapContract Bool () a b
+-- ignoreBigMap baseContract = do
+--   unpair
+--   swap
+--   unpair
+--   dip $ do
+--     swap
+--     pair
+--     baseContract
+--     unpair
+--   swap
+--   dip pair
+--   pair
 
--- | Wrap a `Contract` and return
--- @(BigMapContract, specialized multisig contract)@
-wrapSomeBigMapContract ::
-     forall a b.
-     ( KnownValue a
-     , NoOperation a
-     , NoBigMap a
-     , KnownValue b
-     , NoOperation b
-     , BigMapConstraint (ToT b)
-     )
-  => Contract a b
-  -> (SomeContract, SomeContract)
-wrapSomeBigMapContract baseContract =
-  case checkBigMapPresence (sing @(ToT b)) of
-    BigMapPresent ->
-      case constrainedBigMap (sing @(ToT b)) of
-        Dict ->
-          ( SomeContract $ explicitlyStorePair' baseContract
-          , SomeContract $ wrappedMultisigContractProxy @PublicKey
-              (Proxy @(CValue (CBigMapKey (ToT b))))
-              (Proxy @(Value (CBigMapVal (ToT b))))
-              (Proxy @a)
-              (Proxy @(Value (CWithoutBigMap (ToT b))))
-          )
-    BigMapAbsent ->
-      ( SomeContract $ ignoreBigMap baseContract
-      , SomeContract $ wrappedMultisigContractProxy @PublicKey
-              (Proxy @Bool)
-              (Proxy @())
-              (Proxy @a)
-              (Proxy @(Value (ToT b)))
-      )
+-- -- | Wrap a `Contract` and return
+-- -- @(BigMapContract, specialized multisig contract)@
+-- wrapSomeBigMapContract ::
+--      forall a b.
+--      ( KnownValue a
+--      , NoOperation a
+--      , NoBigMap a
+--      , KnownValue b
+--      , NoOperation b
+--      -- , BigMapConstraint (ToT b)
+--      )
+--   => Contract a b
+--   -> (SomeContract, SomeContract)
+-- wrapSomeBigMapContract baseContract =
+--   case checkBigMapPresence (sing @(ToT b)) of
+--     BigMapPresent ->
+--       case constrainedBigMap (sing @(ToT b)) of
+--         Dict ->
+--           ( SomeContract $ explicitlyStorePair' baseContract
+--           , SomeContract $ wrappedMultisigContractProxy @PublicKey
+--               (Proxy @(CValue (CBigMapKey (ToT b))))
+--               (Proxy @(Value (CBigMapVal (ToT b))))
+--               (Proxy @a)
+--               (Proxy @(Value (CWithoutBigMap (ToT b))))
+--           )
+--     BigMapAbsent ->
+--       ( SomeContract $ ignoreBigMap baseContract
+--       , SomeContract $ wrappedMultisigContractProxy @PublicKey
+--               (Proxy @Bool)
+--               (Proxy @())
+--               (Proxy @a)
+--               (Proxy @(Value (ToT b)))
+--       )
 
 -- | Type-constrained version of `I`
 makeI :: Instr.Contract a b -> Contract (Value a) (Value b)
 makeI = I
 
--- | Wrap `SomeContract`, see `wrapSomeBigMapContract`
-wrapSomeTypeCheckedContract ::
-     Ty.SomeContract
-  -> (SomeContract, SomeContract)
-wrapSomeTypeCheckedContract (Ty.SomeContract baseContract _ _) =
-  wrapSomeBigMapContract $ makeI baseContract
+-- -- | Wrap `SomeContract`, see `wrapSomeBigMapContract`
+-- wrapSomeTypeCheckedContract ::
+--      Ty.SomeContract
+--   -> (SomeContract, SomeContract)
+-- wrapSomeTypeCheckedContract (Ty.SomeContract baseContract) =
+--   wrapSomeBigMapContract $ makeI baseContract
 
 
 -- | @(a `SomeContractParam` parser, a storage value parser)@
@@ -262,91 +264,91 @@ parseTypeCheckValue =
   runTypeCheckIsolated . flip runReaderT def . typeVerifyValue . expandValue <$>
   (value <* eof)
 
--- | Make `StorageParamsParser` for some `Contract`,
--- assuming a `BigMap` occurs in the storage type
-explicitlyStorePairStorageParams ::
-     forall a b.
-     ( KnownValue a
-     , HasNoOp (ToT a)
-     , HasNoBigMap (ToT a)
-     , KnownValue b
-     , HasNoOp (ToT b)
-     , ContainsBigMap (ToT b) ~ 'True
-     , BigMapConstraint (ToT b)
-     )
-  => Contract a b
-  -> StorageParamsParser
-explicitlyStorePairStorageParams baseContract =
-  ( do
-    toSomeContractParam <$> parseTypeCheckValue @(ToT a)
-  , \threshold publicKeys -> do
-    parsedValue <- parseTypeCheckValue @(ToT b)
-    case constrainedBigMap (sing @(ToT b)) of
-      Dict ->
-        case parsedValue of
-          VPair (bigMap', withoutBigMap') ->
-            case fst $ wrapSomeBigMapContract baseContract of
-              SomeContract wrappedBaseContract -> do
-                let contractStorage =
-                      ( bigMap'
-                      , ( (wrappedBaseContract, withoutBigMap')
-                        , ((0 :: Natural), (threshold, publicKeys))))
-                return $ printLorentzValue True contractStorage
-  )
+-- -- | Make `StorageParamsParser` for some `Contract`,
+-- -- assuming a `BigMap` occurs in the storage type
+-- explicitlyStorePairStorageParams ::
+--      forall a b.
+--      ( KnownValue a
+--      , HasNoOp (ToT a)
+--      , HasNoBigMap (ToT a)
+--      , KnownValue b
+--      , HasNoOp (ToT b)
+--      , ContainsBigMap (ToT b) ~ 'True
+--      -- , BigMapConstraint (ToT b)
+--      )
+--   => Contract a b
+--   -> StorageParamsParser
+-- explicitlyStorePairStorageParams baseContract =
+--   ( do
+--     toSomeContractParam <$> parseTypeCheckValue @(ToT a)
+--   , \threshold publicKeys -> do
+--     parsedValue <- parseTypeCheckValue @(ToT b)
+--     case constrainedBigMap (sing @(ToT b)) of
+--       Dict ->
+--         case parsedValue of
+--           VPair (bigMap', withoutBigMap') ->
+--             case fst $ wrapSomeBigMapContract baseContract of
+--               SomeContract wrappedBaseContract -> do
+--                 let contractStorage =
+--                       ( bigMap'
+--                       , ( (wrappedBaseContract, withoutBigMap')
+--                         , ((0 :: Natural), (threshold, publicKeys))))
+--                 return $ printLorentzValue True contractStorage
+--   )
 
--- | Make `StorageParamsParser` for some `Contract`, ignoring any `BigMap`
-ignoreBigMapStorageParams ::
-     forall a b.
-     ( KnownValue a
-     , HasNoOp (ToT a)
-     , HasNoBigMap (ToT a)
-     , KnownValue b
-     , HasNoOp (ToT b)
-     , BigMapConstraint (ToT b)
-     )
-  => Contract a b
-  -> StorageParamsParser
-ignoreBigMapStorageParams baseContract =
-  ( do
-    toSomeContractParam <$> parseTypeCheckValue @(ToT a)
-  , \threshold publicKeys -> do
-    parsedValue <- parseTypeCheckValue @(ToT b)
-    case fst $ wrapSomeBigMapContract baseContract of
-      SomeContract wrappedBaseContract -> do
-        let contractStorage =
-              ( (mempty :: BigMap Bool ())
-              , ( (wrappedBaseContract, parsedValue)
-                , ((0 :: Natural), (threshold, publicKeys))))
-        return $ printLorentzValue True contractStorage
-  )
+-- -- | Make `StorageParamsParser` for some `Contract`, ignoring any `BigMap`
+-- ignoreBigMapStorageParams ::
+--      forall a b.
+--      ( KnownValue a
+--      , HasNoOp (ToT a)
+--      , HasNoBigMap (ToT a)
+--      , KnownValue b
+--      , HasNoOp (ToT b)
+--      -- , BigMapConstraint (ToT b)
+--      )
+--   => Contract a b
+--   -> StorageParamsParser
+-- ignoreBigMapStorageParams baseContract =
+--   ( do
+--     toSomeContractParam <$> parseTypeCheckValue @(ToT a)
+--   , \threshold publicKeys -> do
+--     parsedValue <- parseTypeCheckValue @(ToT b)
+--     case fst $ wrapSomeBigMapContract baseContract of
+--       SomeContract wrappedBaseContract -> do
+--         let contractStorage =
+--               ( (mempty :: BigMap Bool ())
+--               , ( (wrappedBaseContract, parsedValue)
+--                 , ((0 :: Natural), (threshold, publicKeys))))
+--         return $ printLorentzValue True contractStorage
+--   )
 
--- | Make `StorageParamsParser` for a `Contract`
-wrappedBigMapContractStorageParams ::
-     forall a b.
-     ( KnownValue a
-     , HasNoOp (ToT a)
-     , HasNoBigMap (ToT a)
-     , KnownValue b
-     , HasNoOp (ToT b)
-     , BigMapConstraint (ToT b)
-     )
-  => Contract a b
-  -> StorageParamsParser
-wrappedBigMapContractStorageParams baseContract =
-  case checkBigMapPresence (sing @(ToT b)) of
-    BigMapPresent ->
-      case constrainedBigMap (sing @(ToT b)) of
-        Dict ->
-          explicitlyStorePairStorageParams baseContract
-    BigMapAbsent ->
-      ignoreBigMapStorageParams baseContract
+-- -- | Make `StorageParamsParser` for a `Contract`
+-- wrappedBigMapContractStorageParams ::
+--      forall a b.
+--      ( KnownValue a
+--      , HasNoOp (ToT a)
+--      , HasNoBigMap (ToT a)
+--      , KnownValue b
+--      , HasNoOp (ToT b)
+--      -- , BigMapConstraint (ToT b)
+--      )
+--   => Contract a b
+--   -> StorageParamsParser
+-- wrappedBigMapContractStorageParams baseContract =
+--   case checkBigMapPresence (sing @(ToT b)) of
+--     BigMapPresent ->
+--       case constrainedBigMap (sing @(ToT b)) of
+--         Dict ->
+--           explicitlyStorePairStorageParams baseContract
+--     BigMapAbsent ->
+--       ignoreBigMapStorageParams baseContract
 
--- | Make wrapped storage and parameter parsers for `Ty.SomeContract`
-someBigMapContractStorageParams ::
-     Ty.SomeContract
-  -> StorageParamsParser
-someBigMapContractStorageParams (Ty.SomeContract baseContract _ _) =
-  wrappedBigMapContractStorageParams $ makeI baseContract
+-- -- | Make wrapped storage and parameter parsers for `Ty.SomeContract`
+-- someBigMapContractStorageParams ::
+--      Ty.SomeContract
+--   -> StorageParamsParser
+-- someBigMapContractStorageParams (Ty.SomeContract baseContract) =
+--   wrappedBigMapContractStorageParams $ makeI baseContract
 
 
 -- | A simple contract to store `Natural`'s
@@ -359,9 +361,9 @@ someBigMapContractStorageParams (Ty.SomeContract baseContract _ _) =
 natStorageContract :: Contract Natural Natural
 natStorageContract = varStorageContract
 
--- | `natStorageContract` with explicit `BigMap`
-natStorageWithBigMapContract :: BigMapContract Bool () Natural Natural
-natStorageWithBigMapContract = ignoreBigMap natStorageContract
+-- -- | `natStorageContract` with explicit `BigMap`
+-- natStorageWithBigMapContract :: BigMapContract Bool () Natural Natural
+-- natStorageWithBigMapContract = ignoreBigMap natStorageContract
 
 -- | Multisig-wrapper specialized for `natStorageWithBigMapContract`
 wrappedMultisigContractNat ::
@@ -376,57 +378,57 @@ wrappedMultisigContractNat =
     (Proxy :: Proxy Natural)
     (Proxy :: Proxy Natural)
 
--- | Initialize the storage for `wrappedMultisigContractNat`, given the
--- initial `Natural`, threshold, and list of signer keys.
-initStorageWrappedMultisigContractNat ::
-     Natural
-  -> Natural
-  -> [PublicKey]
-  -> ( BigMap Bool ()
-     , ((BigMapContract Bool () Natural Natural, Natural), Storage PublicKey))
-initStorageWrappedMultisigContractNat initialNat threshold keys =
-  ( mempty
-  , ( (natStorageWithBigMapContract, initialNat)
-    , (storedCounter, (threshold, keys))))
-  where
-    storedCounter = 0
+-- -- | Initialize the storage for `wrappedMultisigContractNat`, given the
+-- -- initial `Natural`, threshold, and list of signer keys.
+-- initStorageWrappedMultisigContractNat ::
+--      Natural
+--   -> Natural
+--   -> [PublicKey]
+--   -> ( BigMap Bool ()
+--      , ((BigMapContract Bool () Natural Natural, Natural), Storage PublicKey))
+-- initStorageWrappedMultisigContractNat initialNat threshold keys =
+--   ( mempty
+--   , ( (natStorageWithBigMapContract, initialNat)
+--     , (storedCounter, (threshold, keys))))
+--   where
+--     storedCounter = 0
 
--- | Multisig-wrapper specialized for `wrappedMultisigContractAthens`
-wrappedMultisigContractAthens ::
-     Contract (Parameter PublicKey A.Parameter) ( BigMap Address LedgerValue
-                                                , ( ( BigMapContract Address LedgerValue A.Parameter A.StorageFields
-                                                    , A.StorageFields)
-                                                  , Storage PublicKey))
-wrappedMultisigContractAthens =
-  wrappedMultisigContractProxy
-    (Proxy :: Proxy Address)
-    (Proxy :: Proxy LedgerValue)
-    (Proxy :: Proxy A.Parameter)
-    (Proxy :: Proxy A.StorageFields)
+-- -- | Multisig-wrapper specialized for `wrappedMultisigContractAthens`
+-- wrappedMultisigContractAthens ::
+--      Contract (Parameter PublicKey ManagedLedger.Parameter) ( BigMap Address LedgerValue
+--                                                 , ( ( BigMapContract Address LedgerValue ManagedLedger.Parameter ManagedLedger.StorageFields
+--                                                     , ManagedLedger.StorageFields)
+--                                                   , Storage PublicKey))
+-- wrappedMultisigContractAthens =
+--   wrappedMultisigContractProxy
+--     (Proxy :: Proxy Address)
+--     (Proxy :: Proxy LedgerValue)
+--     (Proxy :: Proxy ManagedLedger.Parameter)
+--     (Proxy :: Proxy ManagedLedger.StorageFields)
 
--- | Initialize the storage for `wrappedMultisigContractAthens`, given
--- the admin `Address`, whether it's initially paused, the total supply of
--- tokens, `Left` proxy admin or `Right` proxy contract, the threshold,
--- and the list of signer keys.
-initStorageWrappedMultisigContractAthens ::
-     Address
-  -> Bool
-  -> Natural
-  -> Either Address Address
-  -> Natural
-  -> [PublicKey]
-  -> ( BigMap Address LedgerValue
-     , ( ( BigMapContract Address LedgerValue A.Parameter A.StorageFields
-         , A.StorageFields)
-       , Storage PublicKey))
-initStorageWrappedMultisigContractAthens admin paused totalSupply proxy threshold keys =
-  ( mempty
-  , ( (explicitBigMapAthens, A.StorageFields admin paused totalSupply proxy)
-    , (0, (threshold, keys))))
+-- -- | Initialize the storage for `wrappedMultisigContractAthens`, given
+-- -- the admin `Address`, whether it's initially paused, the total supply of
+-- -- tokens, `Left` proxy admin or `Right` proxy contract, the threshold,
+-- -- and the list of signer keys.
+-- initStorageWrappedMultisigContractAthens ::
+--      Address
+--   -> Bool
+--   -> Natural
+--   -> Either Address Address
+--   -> Natural
+--   -> [PublicKey]
+--   -> ( BigMap Address LedgerValue
+--      , ( ( BigMapContract Address LedgerValue ManagedLedger.Parameter ManagedLedger.StorageFields
+--          , ManagedLedger.StorageFields)
+--        , Storage PublicKey))
+-- initStorageWrappedMultisigContractAthens admin paused totalSupply proxy threshold keys =
+--   ( mempty
+--   , ( (explicitBigMapAthens, ManagedLedger.StorageFields admin paused totalSupply proxy)
+--     , (0, (threshold, keys))))
 
--- | `A.managedLedgerAthensContract` with an explicit `BigMap`
-explicitBigMapAthens ::
-     BigMapContract Address LedgerValue A.Parameter A.StorageFields
-explicitBigMapAthens =
-  explicitlyStorePair A.managedLedgerAthensContract
+-- -- | `ManagedLedger.managedLedgerAthensContract` with an explicit `BigMap`
+-- explicitBigMapAthens ::
+--      BigMapContract Address LedgerValue ManagedLedger.Parameter ManagedLedger.StorageFields
+-- explicitBigMapAthens =
+--   explicitlyStorePair managedLedgerContract
 

--- a/src/Lorentz/Contracts/Parse.hs
+++ b/src/Lorentz/Contracts/Parse.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS -Wno-missing-export-lists #-}
+{-# OPTIONS -Wno-orphans #-}
 
 module Lorentz.Contracts.Parse where
 
@@ -20,10 +22,11 @@ import qualified Data.Text as T
 import qualified Options.Applicative.Types as Opt
 
 import Lorentz hiding (contractName)
-import Tezos.Crypto (PublicKey, SecretKey)
+import Tezos.Crypto (PublicKey)
 import Util.Named
 import Lorentz.Contracts.Util ()
 import Michelson.Parser
+-- import qualified Tezos.Crypto.Ed25519 as Ed25519
 
 import qualified Lorentz.Contracts.GenericMultisig as G
 import qualified Lorentz.Contracts.GenericMultisig.Wrapper as G
@@ -90,9 +93,9 @@ parseBool name =
     ]
 
 -- | Parse a `View` by parsing its arguments and @"callback-contract"@ address
-parseView :: Opt.Parser a -> Opt.Parser (View a r)
+parseView :: NiceParameter r => Opt.Parser a -> Opt.Parser (View a r)
 parseView parseArg =
-  View <$> parseArg <*> fmap ContractAddr (parseAddress "callback-contract")
+  View <$> parseArg <*> fmap toContractRef (parseAddress "callback-contract")
 
 -- | Parse the signer keys
 parseSignerKeys :: String -> Opt.Parser [PublicKey]
@@ -201,15 +204,18 @@ parseLambda name description =
     , Opt.help description
     ]
 
--- | Parse a `SecretKey`
-parseSecretKey :: Opt.Parser SecretKey
-parseSecretKey =
-  Opt.option Opt.auto $
-    mconcat
-      [ Opt.long "secretKey"
-      , Opt.metavar "SecretKey"
-      , Opt.help "Private key to sign multisig parameter JSON file"
-      ]
+-- NOTE: It appears that a number of utilities to work with
+-- SecretKey's have been removed from the latest `morley`
+--
+-- -- | Parse a `SecretKey`
+-- parseSecretKey :: Opt.Parser Ed25519.SecretKey
+-- parseSecretKey =
+--   Opt.option Opt.auto $
+--     mconcat
+--       [ Opt.long "secretKey"
+--       , Opt.metavar "SecretKey"
+--       , Opt.help "Private key to sign multisig parameter JSON file"
+--       ]
 
 -- | Parser `G.SomePublicKey`
 parseSomePublicKey :: Opt.Parser G.SomePublicKey

--- a/src/Lorentz/Contracts/SomeContractParam.hs
+++ b/src/Lorentz/Contracts/SomeContractParam.hs
@@ -72,10 +72,10 @@ toSomeContractParam ::
   -> SomeContractParam
 toSomeContractParam xs =
   let singT = sing
-   in case extractNotes (toUType $ fromSing singT) singT of
-        Left err -> error $ P.show err
-        Right notesT ->
-          SomeContractParam (toVal xs) (singT, notesT) (Dict, Dict)
+   in -- case _ (toUType $ fromSing singT) singT of -- extractNotes
+        -- Left err -> error $ P.show err
+        -- Right notesT ->
+          SomeContractParam (toVal xs) (singT, starNotes) (Dict, Dict) -- notesT
 
 -- | Consume `SomeContractParam`
 fromSomeContractParam ::
@@ -94,10 +94,10 @@ instance FromJSON SomeContractParam where
   parseJSON x = do
     (t, uValue) <- parseJSON x
     withSomeSingT t $ \singT -> do
-      notes' <- either (fail . show) return $ extractNotes (toUType t) singT
+      -- notes' <- either (fail . show) return $ starNotes -- extractNotes (toUType t) singT
       ((::::) xs (sing', notesT)) <-
         either (fail . show) return . runTypeCheckInstr $
-        typeCheckValue uValue (singT, notes')
+        typeCheckValue uValue (singT, starNotes) -- notes')
       case opAbsense sing' of
         Nothing -> error $ "SomeContractParam contains operation: " <> P.show xs
         Just dictHasNoOp ->

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,26 +2,31 @@ resolver: lts-13.22
 
 packages:
 - .
-# - prelude
-# - lorentz-contracts
-# - indigo
 
 extra-deps:
 - aeson-options-0.1.0
 - base58-bytestring-0.1.0
+- constraints-0.11
 - hex-text-0.1.0.0
+- pretty-terminal-0.1.0.0
 - show-type-0.1.1
+- first-class-families-0.6.0.0@sha256:9d2a2a0092dfb8fd0e688b0b6bf71242fbc393c028b0b669d25ed387667490c2
+- morley-0.5.0
+- morley-prelude-0.3.0@sha256:9e9473ac14cfa206adf0a3700764c0251de05042f1fe45daf9cb8556079ae663
 
+  # morley-0.5.0 doesn't come with a version of morley-ledgers on hackage
 - git:
     https://gitlab.com/morley-framework/morley.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    06bbe4e0cba9c1cf83bcf61b78666c6b5bb34c34 # master
+    4d825ab1ca9adcafa368a057b18bacfb220ae939 # 0.5.0
   subdirs:
-    - .
-    - lorentz-contracts
-    - prelude
-    - indigo
+    # - .
+    # - prelude
+    # - morley-upgradeable
+    - morley-ledgers
+    - morley-ledgers-test
+    # - indigo
 
 nix:
   shell-file: shell.nix


### PR DESCRIPTION
- Updates to latest morley (0.5.0)
  * Uses new features and data/function versions
- Disables Most of the multisig functionality:
  * `SecretKey` utilities have been removed from `morley`, ostensibly to prevent timing attacks
  * Previous utilities assumed `BigMap` constraints that are different in `Babylon`